### PR TITLE
SplitProvider - Functional and aware of config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A [Split.io](https://www.split.io/) library to easily manage splits in React.
 ## Get Started
 
 - [Installation](#installation)
+- [Configuration](#configuration)
 - [Usage](#usage)
 - [Contributions](#install-dependencies)
 - [All Available Scripts](#all-available-scripts)
@@ -24,7 +25,7 @@ samuelcastro@mac:~$ yarn add react-splitio
 samuelcastro@mac:~$ npm install react-splitio
 ```
 
-## Usage
+## Configuration
 
 On your root component define the Split provider:
 
@@ -33,6 +34,49 @@ On your root component define the Split provider:
   <App />
 </SplitProvider>
 ```
+
+### Performance
+Note that if your `SDK_CONFIG_OBJECT` is defined inside of a component it will create unnecessary work for `SplitProvider`,
+because the object will have a different identity each render (`previousConfig !== newConfig`).
+
+Instead define config outside of your component:
+```tsx
+const config = { ... };
+
+const Root = () => (
+  <SplitProvider config={config}>
+    <App />
+  </SplitProvider>
+)
+```
+Or if you need to configure dynamically, memoize the object:
+```tsx
+const MySplitProvider = ({ trafficType, children }) => {
+  const config = useMemo(() => ({
+    core: {
+      authorizationKey: '',
+      trafficType,
+    }
+  }), [trafficType]);
+  return (
+    <SplitProvider config={config}>
+      {children}
+    </SplitProvider>
+  );
+};
+```
+
+### Impression Listener
+
+Split allows you to [implement a custom impression listener](https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#listener).
+`SplitProvider` has an optional convenience `onImpression` callback you can use instead.
+```tsx
+<SplitProvider config={} onImpression={impressionData => {
+  // do something with the impression data.
+}}>
+```
+
+## Usage
 
 Now assuming you have a split named: `feature1` you can do something like:
 

--- a/src/Split.tsx
+++ b/src/Split.tsx
@@ -16,7 +16,7 @@ const Split: React.SFC<ISplitProps> = ({ name, children }) => (
   <SplitContext.Consumer>
     {({ client, isReady, lastUpdate }: ISplitContextValues) =>
       children(
-        isReady
+        client && isReady
           ? name instanceof Array
             ? client.getTreatmentsWithConfig(name as string[])
             : client.getTreatmentWithConfig(name as string)

--- a/src/SplitProvider.tsx
+++ b/src/SplitProvider.tsx
@@ -1,22 +1,15 @@
 import { SplitFactory } from '@splitsoftware/splitio';
 import React, { createContext } from 'react';
 
-import {
-  ISplitContextValues,
-  ISplitProviderProps,
-  SplitReactContext,
-} from './types';
+import { ISplitContextValues, ISplitProviderProps } from './types';
 
 /**
  * Creating a React.Context with default values.
- * @returns {SplitReactContext}
  */
-export const SplitContext: SplitReactContext = createContext<
-  ISplitContextValues
->({
-  client: {} as SplitIO.IClient,
+export const SplitContext = createContext<ISplitContextValues>({
+  client: null,
   isReady: false,
-  lastUpdate: null,
+  lastUpdate: 0,
 });
 
 /**
@@ -49,7 +42,7 @@ const SplitProvider = class extends React.Component<
     this.state = {
       client: factory.client(),
       isReady: false,
-      lastUpdate: null,
+      lastUpdate: 0,
     };
   }
 
@@ -57,7 +50,7 @@ const SplitProvider = class extends React.Component<
    * Listening for split events
    */
   componentDidMount() {
-    const { client } = this.state;
+    const client = this.state.client!;
 
     /**
      * When SDK is ready this isReady to true
@@ -80,7 +73,7 @@ const SplitProvider = class extends React.Component<
    * Destroying client instance when component unmonts
    */
   componentWillUnmount() {
-    const { client } = this.state;
+    const client = this.state.client!;
 
     client.destroy();
   }

--- a/src/SplitProvider.tsx
+++ b/src/SplitProvider.tsx
@@ -26,6 +26,38 @@ export const SplitContext = createContext<ISplitContextValues>({
  *  </SplitProvider>
  */
 const SplitProvider = ({ config, children }: ISplitProviderProps) => {
+  const {
+    startup = {},
+    scheduler = {},
+    core,
+    features = {},
+    storage = {},
+    debug,
+    impressionListener,
+  } = config;
+  const clientDeps = [
+    startup.readyTimeout,
+    startup.requestTimeoutBeforeReady,
+    startup.retriesOnFailureBeforeReady,
+    startup.eventsFirstPushWindow,
+    scheduler.featuresRefreshRate,
+    scheduler.impressionsRefreshRate,
+    scheduler.metricsRefreshRate,
+    scheduler.segmentsRefreshRate,
+    scheduler.eventsPushRate,
+    scheduler.eventsQueueSize,
+    scheduler.offlineRefreshRate,
+    core.authorizationKey,
+    core.key,
+    core.trafficType,
+    core.labelsEnabled,
+    ...Object.entries(features).map((k, v) => `${k}::${v}`),
+    storage.type,
+    storage.prefix,
+    debug,
+    impressionListener,
+  ];
+
   const [client, setClient] = useState<SplitIO.IClient | null>(null);
   const [isReady, setReady] = useState(false);
   const [lastUpdate, setUpdated] = useState(0);
@@ -49,7 +81,7 @@ const SplitProvider = ({ config, children }: ISplitProviderProps) => {
       setReady(false);
       setUpdated(0);
     };
-  }, []);
+  }, clientDeps);
 
   return (
     <SplitContext.Provider

--- a/src/SplitProvider.tsx
+++ b/src/SplitProvider.tsx
@@ -59,7 +59,10 @@ const SplitProvider = ({
   // Determine whether config has changed which would require client to be recreated.
   // Convert config object to string so it works with the identity check ran with useEffect's dependency list.
   // We memoize this so if the user has memoized their config object we don't call JSON.stringify needlessly.
-  const configHash = useMemo(() => JSON.stringify(config), [config]);
+  // We also freeze the config object here so users know modifying it is not what they want to do.
+  const configHash = useMemo(() => JSON.stringify(deepFreeze(config)), [
+    config,
+  ]);
 
   useEffect(() => {
     // Reset state when re-creating the client after config modification
@@ -109,3 +112,16 @@ const SplitProvider = ({
 };
 
 export default SplitProvider;
+
+const deepFreeze = <T extends {}>(object: T): T => {
+  // Freeze properties before freezing self
+  const propNames = Object.getOwnPropertyNames(object);
+  for (const name of propNames) {
+    const value = object[name];
+    if (value && typeof value === 'object') {
+      object[name] = deepFreeze(value);
+    }
+  }
+
+  return Object.freeze(object);
+};

--- a/src/SplitProvider.tsx
+++ b/src/SplitProvider.tsx
@@ -1,5 +1,11 @@
 import { SplitFactory } from '@splitsoftware/splitio';
-import React, { createContext, useEffect, useMemo, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 import { ISplitContextValues, ISplitProviderProps } from './types';
 
@@ -25,10 +31,28 @@ export const SplitContext = createContext<ISplitContextValues>({
  *    <App />
  *  </SplitProvider>
  */
-const SplitProvider = ({ config, children }: ISplitProviderProps) => {
+const SplitProvider = ({
+  config,
+  children,
+  onImpression,
+}: ISplitProviderProps) => {
   const [client, setClient] = useState<SplitIO.IClient | null>(null);
   const [isReady, setReady] = useState(false);
   const [lastUpdate, setUpdated] = useState(0);
+
+  // Handle impression listener separately from config.
+  // - Allows us to use the onImpression property
+  // - And because the listener function is ignored from JSON.stringify,
+  //   so changing that in the config wouldn't hook up the new function.
+  // - Because of this ^ the function can change without us having to recreate the client.
+  const handleImpression = useCallback((data: SplitIO.ImpressionData) => {
+    if (onImpression) {
+      onImpression(data);
+    }
+    if (config.impressionListener && config.impressionListener.logImpression) {
+      config.impressionListener.logImpression(data);
+    }
+  }, []);
 
   // Determine whether config has changed which would require client to be recreated.
   // Convert config object to string so it works with the identity check ran with useEffect's dependency list.
@@ -37,7 +61,12 @@ const SplitProvider = ({ config, children }: ISplitProviderProps) => {
 
   useEffect(() => {
     /** @link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#2-instantiate-the-sdk-and-create-a-new-split-client */
-    const nextClient = SplitFactory(config).client();
+    const nextClient = SplitFactory({
+      ...config,
+      impressionListener: {
+        logImpression: handleImpression,
+      },
+    }).client();
     setClient(nextClient);
     nextClient.on(nextClient.Event.SDK_READY, () => {
       setReady(true);

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,10 +41,9 @@ export type SplitReactContext = Context<ISplitContextValues>;
 
 /**
  * Split Provider interface. Interface that will be implemented in order to create a split provider
- * with the SDK browse settings information. The provider will create client out of factory listening
+ * with the SDK browser settings. The provider will create client out of factory and listen
  * for SDK events.
  * @interface ISplitProviderProps
- * @see {@link https://docs.split.io/docs/nodejs-sdk-overview#section-listener}
  */
 export interface ISplitProviderProps {
   /**
@@ -53,6 +52,14 @@ export interface ISplitProviderProps {
    * @property {IBrowserSettings} config
    */
   config: IBrowserSettings;
+
+  /**
+   * Called when an impression is evaluated.
+   * This is a convince property that's idiomatic with React. The config option works as well.
+   * @see {@link https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#listener}
+   * @property {Function} onImpression
+   */
+  onImpression?: SplitIO.IImpressionListener['logImpression'];
 
   /**
    * Children of our React Split Provider.

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface ISplitContextValues {
    * @property {SplitIO.IClient} client
    * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#2-instantiate-the-sdk-and-create-a-new-split-client}
    */
-  client: SplitIO.IClient;
+  client: SplitIO.IClient | null;
 
   /**
    * isReady is a property that will show up when the client SDK is ready to be consumed.
@@ -28,9 +28,9 @@ export interface ISplitContextValues {
 
   /**
    * Shows up when was the last SDK update
-   * @property {number | null} lastUpdate
+   * @property {number} lastUpdate
    */
-  lastUpdate: number | null;
+  lastUpdate: number;
 }
 
 /**
@@ -83,7 +83,7 @@ export interface ISplitProps {
    */
   children: (
     treatments: TreatmentWithConfig | TreatmentsWithConfig | null,
-    client: SplitIO.IClient,
-    lastUpdate: number | null,
+    client: SplitIO.IClient | null,
+    lastUpdate: number,
   ) => React.ReactNode;
 }


### PR DESCRIPTION
- Changed `client` to be nullable.
  Now we don't have to fake a default client (`{} as SplitIO.Client`).
  This will prevent error if client is not defined and we try to call `getTreatmentsWithConfig`.
- Changed `lastUpdate` to just be `0` instead of `null` for default.
   Since it is a unix timestamp check 0 functions fine.
- I'm also setting `lastUpdate` to "now" when the client is ready, because I'm pretty sure that's the time it has the treatments loaded from server.
- I'm re-creating the client if the config options have changed.
  By giving all the config options as a dependency list to `useEffect`.
- Converted `SplitProvider` to a function component.