### PR TITLE
Shared Clients

### DIFF
--- a/src/SplitClient.tsx
+++ b/src/SplitClient.tsx
@@ -1,0 +1,46 @@
+import React, {
+  FunctionComponent,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { SplitContext } from './SplitProvider';
+import { ISplitContextValues } from './types';
+
+export interface ISplitClientProps {
+  splitKey: SplitIO.SplitKey;
+  trafficType?: string;
+}
+
+export const SplitClient: FunctionComponent<ISplitClientProps> = ({
+  splitKey,
+  trafficType,
+  children,
+}) => {
+  const { factory, isReady, lastUpdate, client: parentClient } = useContext(
+    SplitContext,
+  );
+  const [client, setClient] = useState(parentClient);
+
+  // create client for splitKey and trafficType
+  useEffect(() => {
+    const nextClient = factory ? factory.client(splitKey, trafficType) : null;
+    setClient(nextClient);
+  }, [factory, splitKey, trafficType]);
+
+  // memoize child context to prevent unnecessary re-renders with object's identity changing
+  const context = useMemo(
+    (): ISplitContextValues => ({
+      client,
+      factory,
+      isReady,
+      lastUpdate,
+    }),
+    [factory, client, isReady, lastUpdate],
+  );
+
+  return (
+    <SplitContext.Provider value={context}>{children}</SplitContext.Provider>
+  );
+};

--- a/src/SplitProvider.tsx
+++ b/src/SplitProvider.tsx
@@ -94,10 +94,7 @@ const SplitProvider = ({
      * @link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK
      */
     const nextFactory: SplitIO.ISDK = SplitFactory(sdkConfig);
-    const nextClient = nextFactory.client(
-      config.core.key,
-      config.core.trafficType,
-    );
+    const nextClient = nextFactory.client();
 
     setProvider({
       client: nextClient,

--- a/src/SplitProvider.tsx
+++ b/src/SplitProvider.tsx
@@ -123,17 +123,19 @@ const SplitProvider = ({
     };
   }, [configHash]);
 
+  // memoize child context to prevent unnecessary re-renders with object's identity changing
+  const context = useMemo(
+    (): ISplitContextValues => ({
+      client,
+      factory,
+      isReady,
+      lastUpdate,
+    }),
+    [factory, client, isReady, lastUpdate],
+  );
+
   return (
-    <SplitContext.Provider
-      value={{
-        client,
-        factory,
-        isReady,
-        lastUpdate,
-      }}
-    >
-      {children}
-    </SplitContext.Provider>
+    <SplitContext.Provider value={context}>{children}</SplitContext.Provider>
   );
 };
 

--- a/src/SplitProvider.tsx
+++ b/src/SplitProvider.tsx
@@ -20,6 +20,7 @@ export const defaultTreatment: TreatmentWithConfig = {
  */
 export const SplitContext = createContext<ISplitContextValues>({
   client: null,
+  factory: null,
   isReady: false,
   lastUpdate: 0,
 });
@@ -42,7 +43,10 @@ const SplitProvider = ({
   children,
   onImpression,
 }: ISplitProviderProps) => {
-  const [client, setClient] = useState<SplitIO.IClient | null>(null);
+  const [{ factory, client }, setProvider] = useState({
+    client: null as SplitIO.IClient | null,
+    factory: null as SplitIO.ISDK | null,
+  });
   const [{ isReady, lastUpdate }, setUpdated] = useState({
     isReady: false,
     lastUpdate: 0,
@@ -89,10 +93,16 @@ const SplitProvider = ({
      * Instantiating a new factory
      * @link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK
      */
-    const factory: SplitIO.ISDK = SplitFactory(sdkConfig);
-    const nextClient = factory.client(config.core.key, config.core.trafficType);
+    const nextFactory: SplitIO.ISDK = SplitFactory(sdkConfig);
+    const nextClient = nextFactory.client(
+      config.core.key,
+      config.core.trafficType,
+    );
 
-    setClient(nextClient);
+    setProvider({
+      client: nextClient,
+      factory: nextFactory,
+    });
 
     // Only make state changes if component is mounted.
     // https://github.com/facebook/react/issues/14369#issuecomment-468267798
@@ -117,6 +127,7 @@ const SplitProvider = ({
     <SplitContext.Provider
       value={{
         client,
+        factory,
         isReady,
         lastUpdate,
       }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Split } from './Split';
+export * from './SplitClient';
 export { default as SplitProvider, SplitContext } from './SplitProvider';
 export * from './useSplit';
 export * from './useTrack';

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ import { Context } from 'react';
  * @interface ISplitContextValues
  */
 export interface ISplitContextValues {
+  factory: SplitIO.ISDK | null;
+
   /**
    * Split client instance
    * @property {SplitIO.IClient} client


### PR DESCRIPTION
This allows using a different clients from the SDK. Fixes #5 

To use:
```tsx
<SplitProvider config={...}>

  <SplitClient splitKey="carson" trafficType="admin">
    <Split feature="foo">
      ...
    </Split>
  </SplitClient>

</SplitProvider>
```

If `SplitClient` is optional and if it isn't specified the default client will be used.
This works as you'd expect a React provider to work, so `SplitClient` can be nested and the closet parent client is used.