### PR TITLE
fix(SplitProvider): trying to freeze an already frozen object

### DIFF
--- a/src/SplitProvider.tsx
+++ b/src/SplitProvider.tsx
@@ -139,6 +139,9 @@ const SplitProvider = ({
 export default SplitProvider;
 
 const deepFreeze = <T extends {}>(object: T): T => {
+  if (Object.isFrozen(object)) {
+    return object;
+  }
   // Freeze properties before freezing self
   const propNames = Object.getOwnPropertyNames(object);
   for (const name of propNames) {


### PR DESCRIPTION
If the memo cache is lost or maybe on hot reload deepFreeze would be called again for the same
config object which had been previously frozen. This makes deepFreeze idempotent instead of choking.

![image](https://user-images.githubusercontent.com/932566/68910898-f5a40c80-0718-11ea-986f-6ed5190b61a8.png)
